### PR TITLE
Test super assignment

### DIFF
--- a/src/som/compiler/ClassGenerationContext.java
+++ b/src/som/compiler/ClassGenerationContext.java
@@ -107,7 +107,7 @@ public class ClassGenerationContext {
     return classSide;
   }
 
-  public som.vmobjects.SClass assemble() {
+  public som.vmobjects.SClass assemble() throws ProgramDefinitionError {
     // build class class name
     String ccname = name.getEmbeddedString() + " class";
 

--- a/src/som/compiler/Parser.java
+++ b/src/som/compiler/Parser.java
@@ -231,7 +231,7 @@ public class Parser {
     expect(EndTerm);
   }
 
-  private void superclass(final ClassGenerationContext cgenc) {
+  private void superclass(final ClassGenerationContext cgenc) throws ProgramDefinitionError {
     SSymbol superName;
     if (sym == Identifier) {
       superName = universe.symbolFor(text);
@@ -929,7 +929,7 @@ public class Parser {
   }
 
   private void genPopVariable(final MethodGenerationContext mgenc,
-      final String var) {
+      final String var) throws ParseError {
     // The purpose of this function is to find out whether the variable to be
     // popped off the stack is a local variable, argument, or object field.
     // This is done by examining all available lexical contexts, starting with
@@ -946,7 +946,11 @@ public class Parser {
         bcGen.emitPOPLOCAL(mgenc, tri.getX(), tri.getY());
       }
     } else {
-      bcGen.emitPOPFIELD(mgenc, universe.symbolFor(var));
+      SSymbol varName = universe.symbolFor(var);
+      if (!mgenc.hasField(varName)) {
+        throw new ParseError("Trying to write to field with the name '" + var + "', but field does not seem exist in class.", Symbol.NONE, this);
+      }
+      bcGen.emitPOPFIELD(mgenc, varName);
     }
   }
 

--- a/src/som/interpreter/Interpreter.java
+++ b/src/som/interpreter/Interpreter.java
@@ -25,6 +25,7 @@
 
 package som.interpreter;
 
+import som.compiler.ProgramDefinitionError;
 import som.vm.Universe;
 import som.vmobjects.SAbstractObject;
 import som.vmobjects.SBlock;
@@ -72,7 +73,7 @@ public class Interpreter {
     getFrame().push(((SObject) getSelf()).getField(fieldIndex));
   }
 
-  private void doPushBlock(final int bytecodeIndex) {
+  private void doPushBlock(final int bytecodeIndex) throws ProgramDefinitionError {
     // Handle the PUSH BLOCK bytecode
     SMethod blockMethod = (SMethod) getMethod().getConstant(bytecodeIndex);
 
@@ -215,7 +216,7 @@ public class Interpreter {
     send(signature, receiver.getSOMClass(universe), bytecodeIndex);
   }
 
-  public SAbstractObject start() {
+  public SAbstractObject start() throws ProgramDefinitionError {
     // Iterate through the bytecodes
     while (true) {
 

--- a/src/som/primitives/SystemPrimitives.java
+++ b/src/som/primitives/SystemPrimitives.java
@@ -24,12 +24,13 @@
 
 package som.primitives;
 
-import som.interpreter.Interpreter;
+import som.compiler.ProgramDefinitionError;
 import som.interpreter.Frame;
+import som.interpreter.Interpreter;
 import som.vm.Universe;
+import som.vmobjects.SAbstractObject;
 import som.vmobjects.SClass;
 import som.vmobjects.SInteger;
-import som.vmobjects.SAbstractObject;
 import som.vmobjects.SPrimitive;
 import som.vmobjects.SString;
 import som.vmobjects.SSymbol;
@@ -47,7 +48,12 @@ public class SystemPrimitives extends Primitives {
       public void invoke(final Frame frame, final Interpreter interpreter) {
         SSymbol argument = (SSymbol) frame.pop();
         frame.pop(); // not required
-        SClass result = universe.loadClass(argument);
+        SClass result = null;
+        try {
+          result = universe.loadClass(argument);
+        } catch (ProgramDefinitionError e) {
+          universe.errorExit(e.toString());
+        }
         frame.push(result != null ? result : universe.nilObject);
       }
     });

--- a/tests/som/tests/BasicInterpreterTests.java
+++ b/tests/som/tests/BasicInterpreterTests.java
@@ -41,7 +41,7 @@ import som.vmobjects.SSymbol;
 @RunWith(Parameterized.class)
 public class BasicInterpreterTests {
 
-  @Parameters
+  @Parameters(name = "{0}.{1} [{index}]")
   public static Iterable<Object[]> data() {
     return Arrays.asList(new Object[][] {
         {"MethodCall", "test", 42, SInteger.class},

--- a/tests/som/tests/BasicInterpreterTests.java
+++ b/tests/som/tests/BasicInterpreterTests.java
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import som.compiler.ProgramDefinitionError;
 import som.vm.Universe;
 import som.vmobjects.SClass;
 import som.vmobjects.SDouble;
@@ -44,6 +45,8 @@ public class BasicInterpreterTests {
   @Parameters(name = "{0}.{1} [{index}]")
   public static Iterable<Object[]> data() {
     return Arrays.asList(new Object[][] {
+        {"Self", "assignSuper", 42, ProgramDefinitionError.class},
+
         {"MethodCall", "test", 42, SInteger.class},
         {"MethodCall", "test2", 42, SInteger.class},
 
@@ -153,12 +156,17 @@ public class BasicInterpreterTests {
   }
 
   @Test
-  public void testBasicInterpreterBehavior() {
+  public void testBasicInterpreterBehavior() throws ProgramDefinitionError {
     Universe u = new Universe(true);
     u.setupClassPath("Smalltalk:TestSuite/BasicInterpreterTests");
 
-    Object actualResult = u.interpret(testClass, testSelector);
-
-    assertEqualsSOMValue(expectedResult, actualResult);
+    try {
+      Object actualResult = u.interpret(testClass, testSelector);
+      assertEqualsSOMValue(expectedResult, actualResult);
+    } catch (ProgramDefinitionError e) {
+      if (resultType != ProgramDefinitionError.class) {
+        throw e;
+      }
+    }
   }
 }

--- a/tests/som/tests/SomTests.java
+++ b/tests/som/tests/SomTests.java
@@ -30,6 +30,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import som.compiler.ProgramDefinitionError;
 import som.vm.Universe;
 
 
@@ -76,7 +77,7 @@ public class SomTests {
   }
 
   @Test
-  public void testSomeTest() {
+  public void testSomeTest() throws ProgramDefinitionError {
     String[] args = {"-cp", "Smalltalk", "TestSuite/TestHarness.som", testName};
 
     // Create Universe

--- a/tests/som/tests/SomTests.java
+++ b/tests/som/tests/SomTests.java
@@ -36,7 +36,7 @@ import som.vm.Universe;
 @RunWith(Parameterized.class)
 public class SomTests {
 
-  @Parameters
+  @Parameters(name = "{0} [{index}]")
   public static Iterable<Object[]> data() {
     return Arrays.asList(new Object[][] {
         {"Array"},


### PR DESCRIPTION
This PR fixes an array out of bounds access to when trying to assign `super`.

Since `super` is a pseudo variable, it's not assignable.
With this change, we at least get an error that we can't try to store into a non-existing object field.

It also updates the SOM core-lib with tests to ensure the desired semantics.